### PR TITLE
Add web home page with stored selection and AutoSpin redirect

### DIFF
--- a/app/src/main/assets/AutoSpin.html
+++ b/app/src/main/assets/AutoSpin.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AutoSpin</title>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const savedOption = localStorage.getItem('selectedOption');
+            const display = document.getElementById('selected');
+            display.textContent = savedOption ? savedOption : 'No option selected';
+        });
+    </script>
+</head>
+<body>
+    <h1>AutoSpin Page</h1>
+    <p>Selected option: <span id="selected"></span></p>
+    <a href="home.html">Back</a>
+</body>
+</html>

--- a/app/src/main/assets/home.html
+++ b/app/src/main/assets/home.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Home</title>
+    <!-- Refer to app/src/main/java/com/ctxone/chetaengineslotv2/HomeActivity.java for Android logic -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            // Restore previously selected option
+            const savedOption = localStorage.getItem('selectedOption');
+            if (savedOption) {
+                const radio = document.querySelector(`input[name="selectedOption"][value="${savedOption}"]`);
+                if (radio) {
+                    radio.checked = true;
+                }
+            }
+            // Save option when changed
+            document.querySelectorAll('input[name="selectedOption"]').forEach(radio => {
+                radio.addEventListener('change', (e) => {
+                    localStorage.setItem('selectedOption', e.target.value);
+                });
+            });
+            // Button action
+            document.getElementById('aktifk').addEventListener('click', () => {
+                const selected = document.querySelector('input[name="selectedOption"]:checked');
+                if (selected) {
+                    localStorage.setItem('selectedOption', selected.value);
+                }
+                window.location.href = 'AutoSpin.html';
+            });
+        });
+    </script>
+</head>
+<body>
+    <h1>Pilih Opsi</h1>
+    <label><input type="radio" name="selectedOption" value="Option1" /> Option 1</label><br />
+    <label><input type="radio" name="selectedOption" value="Option2" /> Option 2</label><br />
+    <button id="aktifk">Aktifkan</button>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple home page with radio options and button that stores selected option to localStorage and navigates to AutoSpin
- include AutoSpin page to display stored selection and reference Android `HomeActivity` for equivalent logic

## Testing
- `./gradlew test` (fails: 'org.gradle.api.artifacts.Dependency org.gradle.api.artifacts.dsl.DependencyHandler.module(java.lang.Object)')

------
https://chatgpt.com/codex/tasks/task_e_689747af361883288827458541add8d7